### PR TITLE
Switch to Alpine 3.16

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,22 +1,22 @@
-FROM alpine:edge
+FROM alpine:3.16
 RUN apk --no-cache add bash
-RUN apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/edge/community/ tini
+RUN apk --no-cache add --repository http://dl-cdn.alpinelinux.org/alpine/v3.16/community/ tini
 
 # install runtime dependencies into rootfs
 ENV rootfs=/var/tmp/docker-phan-rootfs-XXXXXXXXXX
 ENV mirror=http://nl.alpinelinux.org/alpine
 # configure rootfs
-RUN mkdir -p $rootfs/etc/apk && { echo "$mirror/edge/main"; echo "$mirror/edge/community"; } | tee "/etc/apk/repositories" "$rootfs/etc/apk/repositories" >&2
+RUN mkdir -p $rootfs/etc/apk && { echo "$mirror/v3.16/main"; echo "$mirror/v3.16/community"; } | tee "/etc/apk/repositories" "$rootfs/etc/apk/repositories" >&2
 
 # install PHP8 dependencies and build dependencies
-RUN apk --no-cache add php8 php8-sqlite3 php8-mbstring curl php8-openssl php8-phar php8-dom php8-pcntl php8-tokenizer php8-iconv
+RUN apk --no-cache add php php-sqlite3 php-mbstring curl php-openssl php-phar php-dom php-pcntl php-tokenizer php-iconv
 RUN cd /tmp && \
     curl -O https://getcomposer.org/download/2.0.4/composer.phar && \
     printf "c3b2bc477429c923c69f7f9b137e06b2a93c6a1e192d40ffad1741ee5d54760d  composer.phar" | sha256sum -c && \
     mv composer.phar /usr/local/bin
 
 # Use the ast versions provided by alpine
-RUN apk --no-cache --root "/var/tmp/docker-phan-rootfs-XXXXXXXXXX" --keys-dir /etc/apk/keys add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --initdb php8 php8-json php8-sqlite3 php8-mbstring php8-pcntl php8-dom php8-tokenizer php8-iconv php8-pecl-ast tini
+RUN apk --no-cache --root "/var/tmp/docker-phan-rootfs-XXXXXXXXXX" --keys-dir /etc/apk/keys add --initdb php php-json php-sqlite3 php-mbstring php-pcntl php-dom php-tokenizer php-iconv php8-pecl-ast tini
 
 # TODO: Merge into above for downloading phan releases (could use github api instead)
 RUN apk --no-cache add git

--- a/versions/4/Dockerfile
+++ b/versions/4/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine:edge
+FROM alpine:3.16
 ADD rootfs.tar.gz /
 ENTRYPOINT ["/sbin/tini", "-g", "--", "/docker-entrypoint.sh"]


### PR DESCRIPTION
This addresses #3 by switching from edge to v3.16 of Alpine.

Almost all php packages drop the php8 prefix, and are simply php (although `php8-pecl-ast` is an oddball).

I wasn't able to get `./build test` to complete, but below is brief log from running `./build` and using the image to further add packages.

```
$ ./build
<..snip..>
Successfully tagged phanphp/phan:latest
$ docker build -t phan-with-packages .
Sending build context to Docker daemon  7.497MB
Step 1/2 : FROM phanphp/phan:latest
 ---> 17b5d3c27b1d
Step 2/2 : RUN apk --no-cache add php8-zip php8-mysqli
<..snip..>
Successfully tagged phan-with-packages:latest
```

